### PR TITLE
Auto include required framework

### DIFF
--- a/Plugins/iOS/Contacts.mm.meta
+++ b/Plugins/iOS/Contacts.mm.meta
@@ -1,4 +1,53 @@
 fileFormatVersion: 2
 guid: b3f254f92fbde46cfa034f4afea309ea
-DefaultImporter:
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Android:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+    Linux:
+      enabled: 0
+      settings:
+        CPU: x86
+    Linux64:
+      enabled: 0
+      settings:
+        CPU: x86_64
+    OSXIntel:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    OSXIntel64:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    Win:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    Win64:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+    iOS:
+      enabled: 1
+      settings:
+        CompileFlags: 
+        FrameworkDependencies: AddressBook;
   userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Updated the meta file to auto include "AddressBook.framework" every time unity compiles for ios
