### PR TITLE
Fix for empty strings

### DIFF
--- a/Plugins/iOS/Contacts.mm
+++ b/Plugins/iOS/Contacts.mm
@@ -128,7 +128,7 @@ extern "C" {
     
     void contact_writeString( NSOutputStream *oStream, NSString* str )
     {
-        if( str == NULL )
+        if( str == NULL || str.length == 0 )
         {
             short size = 0;
             [oStream write:(uint8_t *)&size maxLength:2];


### PR DESCRIPTION
The component doesn't feel well when trying to write zero bytes into oStream which should be governed separately